### PR TITLE
Added a check for start tour in handleVisitStep.ts

### DIFF
--- a/src/handlers/handleVisitStep.ts
+++ b/src/handlers/handleVisitStep.ts
@@ -111,7 +111,7 @@ function goToStep(tgInstance: TourGuideClient, stepIndex : number){
         }
 
         // Before leave callback on current step
-        if (currentStep.beforeLeave) {
+        if (stepIndex !== currentStepIndex && currentStep.beforeLeave) {
             try {
                 await currentStep.beforeLeave(currentStep, nextStep)
             } catch (e){
@@ -164,7 +164,7 @@ function goToStep(tgInstance: TourGuideClient, stepIndex : number){
 
         /** After callbacks **/
         // After leave callback for current step
-        if (currentStep.afterLeave) await currentStep.afterLeave(currentStep, nextStep)
+        if (stepIndex !== currentStepIndex && currentStep.afterLeave) await currentStep.afterLeave(currentStep, nextStep)
 
         // After enter callback for next pending step (now the active step)
         if (nextStep.afterEnter) await nextStep.afterEnter(currentStep, nextStep)


### PR DESCRIPTION
At the start of the tour beforeLeave and afterLeave actions are triggered for the first action together with beforeEnter and afterEnter, this happens because this.activeStep is equal to stepIndex passed to goToStep function. In order to fix that, I'm running equality check for the index before running action for the current step.